### PR TITLE
Change macOS-based runners to macOS v12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
   # Build Eclipse eMoflon macOS user
   build-macos-user:
     needs: [create-splash-image, collect-github-api-artifacts]
-    runs-on: [macos-latest]
+    runs-on: [macos-12]
     steps:
       - name: Start message
         run: echo "Started CI build (Eclipse eMoflon macOS user)."
@@ -296,7 +296,7 @@ jobs:
   # Build Eclipse eMoflon macOS dev
   build-macos-dev:
     needs: [create-splash-image, collect-github-api-artifacts]
-    runs-on: [macos-latest]
+    runs-on: [macos-12]
     steps:
       - name: Start message
         run: echo "Started CI build (Eclipse eMoflon macOS dev)."
@@ -335,7 +335,7 @@ jobs:
   # Build Eclipse eMoflon macOS dev HiPE
   build-macos-dev-hipe:
     needs: [create-splash-image, collect-github-api-artifacts]
-    runs-on: [macos-latest]
+    runs-on: [macos-12]
     steps:
       - name: Start message
         run: echo "Started CI build (Eclipse eMoflon macOS dev HiPE)."


### PR DESCRIPTION
This also resolves a warning on all macOS-based CI runners.