### PR TITLE
Revert "Removes additional plugin: PMD (incompatibility)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Furthermore, all pattern matcher integrations for eMoflon::IBeX (HiPE and Democl
 **Additional packages** are installed for every non-CI build.
 Currently, the list of additional packages includes:
 - [EclEmma](https://www.eclemma.org/)
+- [PMD](https://pmd.github.io/latest/index.html)
 - [Checkstyle](https://checkstyle.org/eclipse-cs/#!/)
 - [SpotBugs](https://spotbugs.github.io/https://spotbugs.github.io/)
 

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ OUTPUT_FILE_PREFIX_LINUX="eclipse-emoflon-linux"
 OUTPUT_FILE_PREFIX_WINDOWS="eclipse-emoflon-windows"
 OUTOUT_FILE_PREFIX_MACOS="eclipse-emoflon-macos"
 MIRROR="https://ftp.fau.de"
-UPDATESITES="https://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/,https://hallvard.github.io/plantuml/,https://hipe-devops.github.io/HiPE-Updatesite/hipe.updatesite/,https://www.kermeta.org/k2/update,https://emoflon.org/emoflon-ibex-updatesite/snapshot/updatesite/,https://www.genuitec.com/updates/devstyle/ci/,https://download.eclipse.org/releases/$VERSION,https://www.codetogether.com/updates/ci/,http://update.eclemma.org/,https://checkstyle.org/eclipse-cs-update-site/,https://spotbugs.github.io/eclipse/"
+UPDATESITES="https://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/,https://hallvard.github.io/plantuml/,https://hipe-devops.github.io/HiPE-Updatesite/hipe.updatesite/,https://www.kermeta.org/k2/update,https://emoflon.org/emoflon-ibex-updatesite/snapshot/updatesite/,https://www.genuitec.com/updates/devstyle/ci/,https://download.eclipse.org/releases/$VERSION,https://www.codetogether.com/updates/ci/,http://update.eclemma.org/,https://pmd.github.io/pmd-eclipse-plugin-p2-site/,https://checkstyle.org/eclipse-cs-update-site/,https://spotbugs.github.io/eclipse/"
 EMOFLON_HEADLESS_SRC="https://api.github.com/repos/eMoflon/emoflon-headless/releases/latest"
 
 # Import plug-in:

--- a/packages/additional-packages.list
+++ b/packages/additional-packages.list
@@ -1,3 +1,4 @@
 org.eclipse.eclemma.feature.feature.group
+net.sourceforge.pmd.eclipse.feature.group
 net.sf.eclipsecs.feature.group
 com.github.spotbugs.plugin.eclipse.feature.group


### PR DESCRIPTION
This reverts commit b52cefadee0cb398f45fc5d6bcc654c8344e823b

This closes https://github.com/eMoflon/emoflon-ibex-eclipse-build/issues/71.

TODO:
- [x] Test the new plug-in version.