### PR TITLE
Fix dependency error with EMF examples

### DIFF
--- a/packages/misc-packages.list
+++ b/packages/misc-packages.list
@@ -1,6 +1,5 @@
 org.eclipse.emf.mwe2.launcher.feature.group
 org.eclipse.emf.mwe2.runtime.sdk.feature.group
 org.eclipse.emf.mwe2.language.sdk.feature.group
-org.eclipse.emf.examples.feature.group
 org.eclipse.collections.feature.feature.group
 org.apache.commons.lang


### PR DESCRIPTION
 Removes `org.eclipse.emf.examples.feature.group` from misc packages.