### PR TITLE
Fixes download errors of eclipse.org by switching back to ftp.fau.de

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ OUTPUT_FILE_PREFIX_LINUX="eclipse-emoflon-linux"
 OUTPUT_FILE_PREFIX_WINDOWS="eclipse-emoflon-windows"
 OUTOUT_FILE_PREFIX_MACOS="eclipse-emoflon-macos"
 OUTOUT_FILE_PREFIX_MACOSARM="eclipse-emoflon-macos-arm"
-MIRROR="https://www.eclipse.org/downloads/download.php?file="
+MIRROR="https://ftp.fau.de"
 UPDATESITES="https://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/,https://hallvard.github.io/plantuml/,https://hipe-devops.github.io/HiPE-Updatesite/hipe.updatesite/,https://www.kermeta.org/k2/update,https://emoflon.org/emoflon-ibex-updatesite/snapshot/updatesite/,https://www.genuitec.com/updates/devstyle/ci/,https://download.eclipse.org/releases/$VERSION,https://www.codetogether.com/updates/ci/,http://update.eclemma.org/,https://pmd.github.io/pmd-eclipse-plugin-p2-site/,https://checkstyle.org/eclipse-cs-update-site/,https://spotbugs.github.io/eclipse/,https://download.eclipse.org/technology/m2e/releases/latest"
 EMOFLON_HEADLESS_SRC="https://api.github.com/repos/eMoflon/emoflon-headless/releases/latest"
 
@@ -207,7 +207,7 @@ remove_update_sites () {
 # Check if script needs to download the initial Eclipse archive.
 if [[ ! -f "./$ARCHIVE_FILE" ]]; then
 	log "Downloading Eclipse $VERSION archive from $MIRROR."
-	wget -q "$MIRROR/technology/epp/downloads/release/$VERSION/R/$ARCHIVE_FILE&r=1" -O $ARCHIVE_FILE
+	wget -q $MIRROR/eclipse/technology/epp/downloads/release/$VERSION/R/$ARCHIVE_FILE
 fi
 
 if [[ "$MODE" = "user" ]]; then


### PR DESCRIPTION
Revert "Switches the download source for all Eclipse archives to eclipse.org"

This reverts commit 193e2ed49e44ef5b3aa0f03e52f39220092e58aa.