### PR TITLE
Update instructions to run Eclipse on macOS

### DIFF
--- a/doc/how-to-run-eclipse-on-macos.md
+++ b/doc/how-to-run-eclipse-on-macos.md
@@ -21,15 +21,15 @@ The following steps are necessary to run a custom Eclipse on modern macOS system
 - Allow your Terminal the privileges to `Full Disk Access` and `Developer Tools` in the `Settings` app of macOS.
     - `Settings` -> `Privacy & Security` -> `Full Disk Access` -> Add `Terminal` app and/or toggle its setting to `on`.
     - `Settings` -> `Privacy & Security` -> `Developer Tools` -> Add `Terminal` app and/or toggle its setting to `on`.
-- Install the recommend JDK, e.g., [Eclipse Temurin JDK 17](https://adoptium.net/de/temurin/releases/?os=mac&arch=x64&package=jdk&version=17).
+- Install the recommend JDK, e.g., [Eclipse Temurin JDK 21](https://adoptium.net/de/temurin/releases/?os=mac&arch=x64&package=jdk&version=21).
 - Download the custom Eclipse archive (e.g., from https://emoflon.org or GitHub).
 - Extract it with a double click.
 - Right click on `Eclipse.app` -> `Show Package Contents` -> Navigate into `Contents`.
 - Open `Info.plist` with a text editor of your choice (e.g., [VSCodium](https://vscodium.com/)).
 - Open a Terminal window and run `$ /usr/libexec/java_home`
-    - This should return you a single path to your default Java JDK installation, e.g., `/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home`
-- Leave your Terminal window open and return to your text editor (showing the contents of `Info.plist`). Scroll down into the block below the line `<key>Eclipse</key>` and enter your Java JDK's path with this syntax: `<string>-vm</string><string>$YOUR_PATH/bin/java</string>`
-    - Example: `<string>-vm</string><string>/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home/bin/java</string>`
+    - This should return you a single path to your default Java JDK installation, e.g., `/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home`
+- Leave your Terminal window open and return to your text editor (showing the contents of `Info.plist`). Scroll down into the `<array>` block below the line `<key>Eclipse</key>` and enter your Java JDK's path with this syntax: `<string>-vm</string><string>$YOUR_PATH/bin/java</string>`
+    - Example: `<string>-vm</string><string>/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home/bin/java</string>`
 - Save the file, close your editor, and open your Terminal window again.
 - Navigate the Terminal window to your Eclipse folder using `cd $FOLDER_NAME`, e.g., `cd Downloads/eclipse`.
     - Verify that your custom `Eclipse.app` is located in the currently selected folder via `ls`.
@@ -39,7 +39,7 @@ The following steps are necessary to run a custom Eclipse on modern macOS system
 - As for the `Terminal` app, add the privileges for `Full Disk Access` and `Developer Tools` to your `Eclipse.app`.
 
 You can now start your custom `Eclipse.app` with a double click on it.
-If macOS asks if you really want to start the "broken" app, select `Run`.
+If macOS asks if you really want to start the "broken" app, select `Run`. If there is no option to run it, you can force macOS into opening it by going to the "Privacy and Security" settings and scrolling down to the bottom.
 
 All modifications on the local `Eclipse.app` can also be made with [this script](../scripts/fix-eclipse-app-macos.sh).
 


### PR DESCRIPTION
- Bump to Java:21
- Clarify block where to put Java config
- Add information about running it first time